### PR TITLE
Adds submit form overrides when an image description is missing

### DIFF
--- a/src/sass/masto/_index.scss
+++ b/src/sass/masto/_index.scss
@@ -1,3 +1,4 @@
 @forward 'links';
 @forward 'media';
 @forward 'dm';
+@forward 'submit';

--- a/src/sass/masto/_submit.scss
+++ b/src/sass/masto/_submit.scss
@@ -1,0 +1,18 @@
+/* Highlights the publish button and the missing image message when there is a warning. */
+.compose-form:has(.compose-form__upload__warning) .compose-form__publish .button,
+.compose-form__upload__warning .icon-button {
+  border: medium dashed red;
+}
+
+/* Highlights the edit button to point towards the button that could fix the missing description issue. */
+.compose-form__upload-thumbnail:has(.compose-form__upload__warning) .compose-form__upload__actions .icon-button:has(.fa-pencil) {
+  border: medium dashed lime;
+}
+
+/* Adds an additional text message near the publish button when there is a missing description. */
+.compose-form:has(.compose-form__upload__warning) .compose-form__publish::before {
+  content: "Please, add an image description!";
+  align-self: center;
+  padding: 1em;
+  margin-top: 15px; /* Same as for the publish button to align properly. */
+}


### PR DESCRIPTION
Following up the conversation on mastodon: https://front-end.social/@mia/109349889584290779

This PR adds the style overrides that make it very obvious that the image description is missing when you're writing a mastodon post:

![A screenshot of a new post form with two images, one of which has a description, other misses it, leading to the red outlines appearing over the publish button, “no description added” message, a lime outline over the “edit” button, and an additional “Please, add an image description!” text near the publish button.](https://user-images.githubusercontent.com/177485/202028940-40193c3e-35c9-476c-8c45-25e0833b8016.png)

The styles seem to build correctly: https://deploy-preview-4--front-end-social.netlify.app/css/override.css
