### PR TITLE
Fix missing description selector

### DIFF
--- a/src/sass/masto/_media.scss
+++ b/src/sass/masto/_media.scss
@@ -1,7 +1,7 @@
 .media-gallery__item-thumbnail img:not([alt]),
 .audio-player__canvas:not([title]),
 .video-player video:not([title]),
-.media-gallery__gifv video:not([title]) {
+.media-gallery__gifv video:not([title]):not([aria-label]) {
   border: medium dashed red;
   box-sizing: border-box;
 }


### PR DESCRIPTION
The selector `.media-gallery__gifv video:not([title])` which adds a red outline to video with a missing description does not cover all pages that show media. In some cases, Mastodon does not add a `[title]`, but only a `[aria-label]`.

See https://front-end.social/@bramus/media for example: there the video has a proper description, but it’s set as the `[aria-label]`, therefore showing the red outline show with the current selector.

<img width="1787" alt="image" src="https://user-images.githubusercontent.com/213073/203286266-1a67dcf4-79f3-4566-9174-90afbe1aeec9.png">

On [the page showing the ~~tweet~~ _toot_](https://front-end.social/@bramus/109382713177862052) it does include a `[title]`

<img width="1787" alt="image" src="https://user-images.githubusercontent.com/213073/203286827-0a6e5642-a9dd-4716-9c58-56acac429895.png">

This is most likely a small oversight in Mastodon itself. This PR adjusts the selector to also track `[aria-label]`.



