### PR TITLE
A more subtle approach to alt highlights

### DIFF
--- a/src/sass/masto/_media.scss
+++ b/src/sass/masto/_media.scss
@@ -1,18 +1,34 @@
-.media-gallery__item-thumbnail img:not([alt]),
-.audio-player__canvas:not([title]),
-.video-player video:not([title]),
-.media-gallery__gifv video:not([title]) {
-  border: medium dashed red;
+/* A thin border for images showing alt text status */
+.media-gallery__item img {
+  border: thin solid red;
   box-sizing: border-box;
 }
 
-.media-gallery__item-thumbnail:has(img:not([alt]))::after {
-  content: 'No image description';
+.media-gallery__item img[alt] {
+  border-color: green;
+}
+
+/* Remove the border if we can do better with :has() */
+.media-gallery__item:has(img) img {
+  border: none;
+}
+
+/* Apply an alt-text badge using generated content */
+.media-gallery__item:has(img)::after {
   background: maroon;
+  border-radius: 3px;
   color: mistyrose;
+  content: "no alt";
   display: inline-block;
-  padding: 0.1rem 0.4rem;
+  inset-block-end: 0.5em;
+  inset-inline-start: 0.5em;
+  padding: 0.25rem 0.5rem;
   position: absolute;
-  inset-block-start: 0;
-  inset-inline-end: 0;
+  pointer-events: none;
+  z-index: 2;
+}
+
+.media-gallery__item:has(img[alt])::after {
+  background: darkgreen;
+  content: "alt";
 }

--- a/src/sass/masto/_media.scss
+++ b/src/sass/masto/_media.scss
@@ -1,25 +1,46 @@
-/* A thin border for images showing alt text status */
-.media-gallery__item img {
-  border: thin solid red;
-  box-sizing: border-box;
+/* show when images have alt text */
+.media-gallery__item {
+  --alt-crop-x: 6ch;
+  --alt-crop-y: 2em;
+  background: darkgreen;
+  color: white;
 }
 
+/* only revealed by cutaway when alt is defined */
+.media-gallery__item::after {
+  content: 'alt';
+  display: grid;
+  inset-block-end: 0;
+  inset-inline-start: 0;
+  min-height: var(--alt-crop-y);
+  min-width: var(--alt-crop-x);
+  place-content: center;
+  position: absolute;
+}
+
+/* cut away to reveal badge */
 .media-gallery__item img[alt] {
-  border-color: green;
+  clip-path: polygon(
+    0 0, 100% 0,
+    100% 100%,
+    var(--alt-crop-x) 100%,
+    var(--alt-crop-x) calc(100% - var(--alt-crop-y)),
+    0 calc(100% - var(--alt-crop-y))
+  );
 }
 
-/* Remove the border if we can do better with :has() */
-.media-gallery__item:has(img) img {
-  border: none;
+/* Remove the clip path if we can do better with :has() */
+.media-gallery__item:has(img) img[alt] {
+  clip-path: none;
 }
 
-/* Apply an alt-text badge using generated content */
+/* Apply better alt-text badge over top of image */
 .media-gallery__item:has(img)::after {
-  background: maroon;
+  --alt-crop-x: initial;
+  --alt-crop-y: initial;
+  background: darkgreen;
+  border: thin solid #fff6;
   border-radius: 3px;
-  color: mistyrose;
-  content: "no alt";
-  display: inline-block;
   inset-block-end: 0.5em;
   inset-inline-start: 0.5em;
   padding: 0.25rem 0.5rem;
@@ -28,7 +49,8 @@
   z-index: 2;
 }
 
-.media-gallery__item:has(img[alt])::after {
-  background: darkgreen;
-  content: "alt";
+/* Change badge when no alt is defined */
+.media-gallery__item:has(img:not([alt]))::after {
+  background: maroon;
+  content: "no alt";
 }

--- a/src/sass/masto/_submit.scss
+++ b/src/sass/masto/_submit.scss
@@ -1,23 +1,24 @@
-// Form highlights when media is missing description.
+/* Form highlights when media is missing description. */
+/* Originally contributed by @kizu */
 
-// The edit button (for fixing the error)
+/* The edit button (for fixing the error) */
 .compose-form__upload__actions:not(:last-child) .icon-button:last-child {
   background-color: darkgreen;
 }
 
-// The warning itself
+/* The warning itself */
 .compose-form__upload__warning button {
   background-color: maroon;
   text-align: left;
   width: 100%;
 }
 
-// The upload area
+/* The upload area */
 .compose-form__upload:has(.compose-form__upload__warning) {
   outline: medium dashed red;
 }
 
-// The form submission
+/* The form submission */
 .compose-form:has(.compose-form__upload__warning) {
   .compose-form__publish [type=submit] {
     border: medium solid red;


### PR DESCRIPTION
Show when alt text is present on images or not, with more subtle styling that doesn't imply missing alt is always an error.